### PR TITLE
Configuração HikariCP limite de conexões para 10

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,6 +48,13 @@ spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
+# Configurações do Pool HikariCP
+spring.datasource.hikari.minimum-idle=5         # mínimo de conexões em idle
+spring.datasource.hikari.maximum-pool-size=10   # máximo de conexões no pool
+spring.datasource.hikari.idle-timeout=300000    # 5 minutos
+spring.datasource.hikari.max-lifetime=600000    # 10 minutos
+spring.datasource.hikari.connection-timeout=30000 # 30 segundos
+
 # ====================================================================
 # DEVTOOLS
 # ====================================================================
@@ -71,3 +78,5 @@ logging.level.org.springframework.http=DEBUG
 # Logging específico do Hibernate
 logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
+# HikariCP
+logging.level.com.zaxxer.hikari=DEBUG


### PR DESCRIPTION
Ajustes de configuração de pool de conexões para obedecer ao limite de conexões simultâneas (15) imposto pelo MySQL no Heroku. Inclui parâmetros de maximum-pool-size, minimum-idle, idle-timeout e max-lifetime no HikariCP, garantindo que a aplicação não exceda os recursos do banco de dados em picos de uso.